### PR TITLE
fix: fix the initial state of the current page

### DIFF
--- a/03-router-and-zustand/src/pages/Search.jsx
+++ b/03-router-and-zustand/src/pages/Search.jsx
@@ -22,8 +22,8 @@ const useFilters = () => {
   const [textToFilter, setTextToFilter] = useState(() => searchParams.get('text') || '')
 
   const [currentPage, setCurrentPage] = useState(() => {
-    const page = Number(searchParams.get('page'))
-    return Number.isNaN(page) ? page : 1
+    const page = parseInt(searchParams.get('page'))
+    return Number.isNaN(page) ? 1 : page
   })
 
   const [jobs, setJobs] = useState([])


### PR DESCRIPTION
This change solves a problem loading the page the first time. In the current version, an url like "search/page=2" will fail. Besides, I replaced the Number for the parseInt function that returns a NaN if the param "page" is empty, with Number it returns 0