### PR TITLE
Se añade optional chaining a permission

### DIFF
--- a/04-node/manage-files.js
+++ b/04-node/manage-files.js
@@ -3,14 +3,14 @@ import { join, basename, extname } from 'node:path'
 
 let content = ''
 
-if (process.permission.has('fs.read', 'archivo.txt')) {
+if (process.permission?.has('fs.read', 'archivo.txt')) {
   content = await readFile('archivo.txt', 'utf-8')
   console.log(content)
 } else {
   console.log('No tienes permiso para leer el archivo.')
 }
 
-if (process.permission.has('fs.write', 'output/files/documents')) {
+if (process.permission?.has('fs.write', 'output/files/documents')) {
 const outputDir = join('output', 'files', 'documents')
 await mkdir(outputDir, { recursive: true })
 


### PR DESCRIPTION
Cuando se llama al fichero sin el sistema de permisos ( node manage-files.js ) da error por que el process.permission no esta definido.

Actual: 
<img width="968" height="318" alt="image" src="https://github.com/user-attachments/assets/88d40d60-61f8-4409-baa9-c6a4e0c9d221" />

Post cambio: 
<img width="723" height="92" alt="image" src="https://github.com/user-attachments/assets/d1ffd302-ca5e-4126-ae03-1651dc3ab9f3" />
